### PR TITLE
Refresh UI and stabilize assistant interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,126 +6,501 @@
   <title>AluIA - Supporto Psicologico</title>
   <script src="./edv.js" defer></script>
   <style>
-    * { margin: 0; padding: 0; box-sizing: border-box; }
-    body {
-      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-      background: linear-gradient(135deg, #E8F4FD 0%, #F0F8FF 50%, #E8F4FD 100%);
-      min-height: 100vh; padding: 20px; transition: all 0.3s ease;
+    :root {
+      color-scheme: light dark;
+      --bg-gradient: radial-gradient(circle at 0% 0%, rgba(118, 174, 241, 0.25), transparent 55%),
+        radial-gradient(circle at 85% 0%, rgba(255, 214, 165, 0.28), transparent 60%),
+        linear-gradient(135deg, #eaf2ff 0%, #f9fbff 100%);
+      --card-bg: rgba(255, 255, 255, 0.96);
+      --card-border: rgba(255, 255, 255, 0.55);
+      --text-main: #23344a;
+      --text-soft: #6f7d90;
+      --accent: #4a90e2;
+      --accent-soft: rgba(74, 144, 226, 0.12);
+      --accent-strong: #1b68c6;
+      --danger: #d32f2f;
+      --success: #2ecc71;
+      --warning: #ff9500;
+      --shadow-soft: 0 12px 36px rgba(31, 64, 102, 0.16);
     }
-    body.dark-mode { background: linear-gradient(135deg, #2c3e50 0%, #34495e 100%); }
-    .container { max-width: 1200px; margin: 0 auto; display: grid; grid-template-columns: 1fr 1fr; gap: 30px; align-items: start; }
-    @media (max-width: 768px) { .container { grid-template-columns: 1fr; gap: 20px; } }
-    .card { background: rgba(255,255,255,0.98); border-radius: 20px; padding: 30px; box-shadow: 0 8px 32px rgba(0,0,0,0.06); backdrop-filter: blur(10px); border: 1px solid rgba(255,255,255,0.8); transition: all 0.3s ease; }
-    body.dark-mode .card { background: rgba(52,73,94,0.95); color: #ecf0f1; border: 1px solid rgba(255,255,255,0.1); }
-    .card ol { color: #52637a; }
-    body.dark-mode .card ol { color: #d5dde5; }
-    .header { text-align: center; margin-bottom: 30px; grid-column: 1 / -1; }
-    .header h1 { font-size: 3rem; color: #4A90E2; margin-bottom: 10px; font-weight: 600; }
-    body.dark-mode .header h1 { color: #74b9ff; }
-    .header p { font-size: 1.2rem; color: #7B8FA3; font-weight: 400; }
-    body.dark-mode .header p { color: #bdc3c7; }
-    .status-bar { position: fixed; top: 20px; right: 20px; background: #FF9500; color: #fff; padding: 10px 20px; border-radius: 25px; font-weight: bold; z-index: 1000; backdrop-filter: blur(10px); border: none; box-shadow: 0 4px 12px rgba(255,149,0,0.3); }
-    .status-bar.connected { background: #4CAF50; }
-    .status-bar.error { background: #d32f2f; }
-    .theme-toggle { position: fixed; top: 20px; left: 20px; background: rgba(255,255,255,0.95); border: none; border-radius: 50%; width: 50px; height: 50px; font-size: 1.5rem; cursor: pointer; backdrop-filter: blur(10px); transition: all 0.3s ease; z-index: 1000; box-shadow: 0 4px 12px rgba(0,0,0,0.1); }
-    body.dark-mode .theme-toggle { background: rgba(52,73,94,0.9); }
-    .theme-toggle:hover { transform: scale(1.1); box-shadow: 0 6px 16px rgba(0,0,0,0.15); }
-    .section-title { font-size: 1.5rem; color: #4A90E2; margin-bottom: 20px; display: flex; align-items: center; gap: 10px; font-weight: 600; }
-    body.dark-mode .section-title { color: #74b9ff; }
+
+    body.dark-mode {
+      --bg-gradient: radial-gradient(circle at 0% 0%, rgba(74, 137, 220, 0.23), transparent 55%),
+        radial-gradient(circle at 100% 10%, rgba(105, 96, 236, 0.22), transparent 65%),
+        linear-gradient(135deg, #1f2933 0%, #141c26 100%);
+      --card-bg: rgba(31, 43, 58, 0.92);
+      --card-border: rgba(148, 176, 210, 0.15);
+      --text-main: #e8f1ff;
+      --text-soft: #b3c1d3;
+      --accent: #74b9ff;
+      --accent-soft: rgba(116, 185, 255, 0.18);
+      --accent-strong: #4aa3ff;
+      --danger: #ef5350;
+      --success: #6dd3a3;
+      --warning: #f5ab35;
+      --shadow-soft: 0 18px 48px rgba(10, 15, 24, 0.45);
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: 'Segoe UI', 'San Francisco', 'Helvetica Neue', Arial, sans-serif;
+      background: var(--bg-gradient);
+      min-height: 100vh;
+      padding: 24px;
+      transition: background 0.6s ease, color 0.3s ease;
+      color: var(--text-main);
+      position: relative;
+      overflow-x: hidden;
+    }
+
+    body::before, body::after {
+      content: '';
+      position: fixed;
+      width: 420px;
+      height: 420px;
+      background: radial-gradient(circle, rgba(255, 255, 255, 0.2) 0%, transparent 65%);
+      top: -160px;
+      border-radius: 50%;
+      z-index: -2;
+      pointer-events: none;
+      transition: opacity 0.6s ease;
+    }
+
+    body::after {
+      top: auto;
+      bottom: -220px;
+      right: -120px;
+      left: auto;
+      background: radial-gradient(circle, rgba(255, 255, 255, 0.16) 0%, transparent 70%);
+    }
+
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+      display: grid;
+      grid-template-columns: repeat(12, 1fr);
+      gap: 28px;
+      align-items: start;
+      position: relative;
+      z-index: 1;
+    }
+
+    @media (max-width: 960px) { .container { grid-template-columns: repeat(6, 1fr); } }
+    @media (max-width: 720px) { body { padding: 16px; } .container { grid-template-columns: repeat(1, minmax(0, 1fr)); gap: 18px; } }
+
+    .card {
+      background: var(--card-bg);
+      border-radius: 26px;
+      padding: 34px;
+      box-shadow: var(--shadow-soft);
+      border: 1px solid var(--card-border);
+      transition: transform 0.35s ease, box-shadow 0.35s ease, border-color 0.3s ease;
+      backdrop-filter: blur(12px);
+    }
+
+    .card:hover { transform: translateY(-6px); box-shadow: 0 18px 48px rgba(26, 62, 102, 0.18); }
+
+    .container > .card:not(.header) { grid-column: span 6; }
+    .card.card--full { grid-column: 1 / -1; }
+    @media (max-width: 960px) { .container > .card:not(.header) { grid-column: span 6; } }
+    @media (max-width: 720px) { .container > .card:not(.header) { grid-column: 1 / -1; } }
+
+    .header {
+      text-align: center;
+      margin-bottom: 20px;
+      grid-column: 1 / -1;
+      background: linear-gradient(135deg, rgba(74, 144, 226, 0.12), rgba(135, 206, 250, 0.08));
+      border: 1px solid rgba(74, 144, 226, 0.2);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .header::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 15% 20%, rgba(255, 255, 255, 0.35), transparent 55%),
+        radial-gradient(circle at 85% 30%, rgba(116, 185, 255, 0.25), transparent 50%);
+      opacity: 0.7;
+      pointer-events: none;
+    }
+
+    .header h1 {
+      font-size: clamp(2.6rem, 5vw, 3.4rem);
+      color: var(--accent-strong);
+      margin-bottom: 12px;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      position: relative;
+    }
+
+    .header p { font-size: 1.2rem; color: var(--text-soft); font-weight: 400; position: relative; }
+
+    .status-bar {
+      position: fixed;
+      top: 24px;
+      right: 24px;
+      background: var(--warning);
+      color: #fff;
+      padding: 12px 22px;
+      border-radius: 999px;
+      font-weight: 600;
+      z-index: 1000;
+      backdrop-filter: blur(10px);
+      border: none;
+      box-shadow: 0 12px 24px rgba(0, 0, 0, 0.12);
+      letter-spacing: 0.01em;
+    }
+
+    .status-bar.connected { background: var(--success); }
+    .status-bar.error { background: var(--danger); }
+    .status-bar.demo { background: var(--warning); }
+
+    .theme-toggle {
+      position: fixed;
+      top: 24px;
+      left: 24px;
+      background: rgba(255, 255, 255, 0.88);
+      border: none;
+      border-radius: 50%;
+      width: 52px;
+      height: 52px;
+      font-size: 1.5rem;
+      cursor: pointer;
+      backdrop-filter: blur(14px);
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
+      z-index: 1000;
+      box-shadow: 0 12px 28px rgba(0, 0, 0, 0.12);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    body.dark-mode .theme-toggle { background: rgba(38, 52, 68, 0.9); }
+    .theme-toggle:hover { transform: translateY(-3px); box-shadow: 0 18px 32px rgba(0, 0, 0, 0.18); }
+
+    .section-title {
+      font-size: 1.5rem;
+      color: var(--accent-strong);
+      margin-bottom: 24px;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      font-weight: 600;
+      letter-spacing: -0.01em;
+    }
+
     .microphone-section { text-align: center; }
-    .microphone-button { width: 120px; height: 120px; border-radius: 50%; background: #4A90E2; border: none; color: #fff; font-size: 2.5rem; cursor: pointer; margin: 20px auto; display: block; transition: all 0.3s ease; box-shadow: 0 8px 24px rgba(74,144,226,0.3); position: relative; overflow: hidden; }
-    .microphone-button:hover { transform: scale(1.05); box-shadow: 0 12px 32px rgba(74,144,226,0.4); }
-    .microphone-button.listening { background: #e74c3c; animation: pulse 2s infinite; box-shadow: 0 8px 24px rgba(231,76,60,0.4); }
-    .microphone-button.disabled { background: #95a5a6; box-shadow: 0 4px 12px rgba(149,165,166,0.3); animation: none; }
-    @keyframes pulse { 0%{transform:scale(1)} 50%{transform:scale(1.05)} 100%{transform:scale(1)} }
-    .microphone-status { background: rgba(74,144,226,0.1); border: 2px solid #4A90E2; border-radius: 25px; padding: 15px; margin: 20px 0; font-weight: 600; color: #4A90E2; transition: all 0.3s ease; }
-    body.dark-mode .microphone-status { background: rgba(74,144,226,0.2); color: #74b9ff; }
-    .microphone-status.active { background: rgba(76,175,80,0.1); border-color: #4CAF50; color: #4CAF50; }
-    .microphone-status.disabled { background: rgba(149,165,166,0.1); border-color: #95a5a6; color: #95a5a6; }
-    body.dark-mode .microphone-status.active { color: #81C784; }
-    .transcript-area { background: rgba(248,249,250,0.8); border: 2px dashed #D1D9E0; border-radius: 15px; padding: 20px; min-height: 100px; margin: 20px 0; font-style: italic; color: #7B8FA3; transition: all 0.3s ease; }
-    body.dark-mode .transcript-area { background: rgba(108,117,125,0.2); color: #95a5a6; }
-    .transcript-area.has-content { background: rgba(74,144,226,0.05); border-color: #4A90E2; color: #2c3e50; font-style: normal; }
-    body.dark-mode .transcript-area.has-content { color: #ecf0f1; }
-    .microphone-help { background: rgba(255,193,7,0.08); border: 1px solid #FFE082; border-radius: 15px; padding: 15px; margin: 20px 0; font-size: 0.9rem; }
-    body.dark-mode .microphone-help { background: rgba(255,193,7,0.15); }
-    .microphone-help h4 { color: #FF9500; margin-bottom: 10px; font-weight: 600; }
-    .microphone-help ol { margin-left: 20px; }
-    .microphone-help li { margin: 5px 0; color: #8D6E63; }
-    body.dark-mode .microphone-help li { color: #FFCC80; }
+
+    .microphone-button {
+      width: 126px;
+      height: 126px;
+      border-radius: 50%;
+      background: linear-gradient(145deg, var(--accent), var(--accent-strong));
+      border: none;
+      color: #fff;
+      font-size: 2.5rem;
+      cursor: pointer;
+      margin: 22px auto;
+      display: grid;
+      place-items: center;
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
+      box-shadow: 0 18px 35px rgba(74, 144, 226, 0.35);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .microphone-button::after {
+      content: '';
+      position: absolute;
+      inset: 15%;
+      border-radius: 50%;
+      background: rgba(255, 255, 255, 0.16);
+      opacity: 0;
+      transition: opacity 0.3s ease;
+    }
+
+    .microphone-button:hover { transform: translateY(-4px) scale(1.03); box-shadow: 0 24px 42px rgba(74, 144, 226, 0.45); }
+    .microphone-button:hover::after { opacity: 1; }
+
+    .microphone-button.listening {
+      background: linear-gradient(145deg, #ff5f6d, #d32f2f);
+      animation: pulse 2s infinite;
+      box-shadow: 0 18px 38px rgba(211, 47, 47, 0.35);
+    }
+
+    .microphone-button.disabled {
+      background: linear-gradient(135deg, #b0bec5, #90a4ae);
+      box-shadow: 0 12px 22px rgba(120, 144, 156, 0.25);
+      animation: none;
+      cursor: not-allowed;
+    }
+
+    @keyframes pulse { 0% { transform: translateY(0) scale(1); } 50% { transform: translateY(-3px) scale(1.07); } 100% { transform: translateY(0) scale(1); } }
+
+    .microphone-status {
+      background: var(--accent-soft);
+      border: 1px solid rgba(74, 144, 226, 0.28);
+      border-radius: 20px;
+      padding: 16px 20px;
+      margin: 22px 0;
+      font-weight: 600;
+      color: var(--accent-strong);
+      transition: background 0.3s ease, border-color 0.3s ease, color 0.3s ease;
+    }
+
+    .microphone-status.active { background: rgba(46, 204, 113, 0.12); border-color: rgba(46, 204, 113, 0.35); color: var(--success); }
+    .microphone-status.disabled { background: rgba(149, 165, 166, 0.14); border-color: rgba(149, 165, 166, 0.25); color: #95a5a6; }
+
+    .transcript-area {
+      background: rgba(248, 249, 252, 0.86);
+      border: 2px dashed rgba(74, 144, 226, 0.28);
+      border-radius: 18px;
+      padding: 22px;
+      min-height: 110px;
+      margin: 22px 0;
+      font-style: italic;
+      color: var(--text-soft);
+      transition: background 0.3s ease, border-color 0.3s ease, color 0.3s ease;
+    }
+
+    .transcript-area.has-content { background: rgba(74, 144, 226, 0.06); border-color: rgba(74, 144, 226, 0.45); color: var(--text-main); font-style: normal; }
+
+    .microphone-help {
+      background: rgba(255, 193, 7, 0.08);
+      border: 1px solid rgba(255, 193, 7, 0.28);
+      border-radius: 18px;
+      padding: 18px;
+      margin: 18px 0;
+      font-size: 0.95rem;
+      line-height: 1.6;
+      color: var(--text-soft);
+    }
+
+    .microphone-help h4 { color: #ffb74d; margin-bottom: 12px; font-weight: 600; }
+    .microphone-help li { margin: 6px 0; }
+
     .chat-section { display: flex; flex-direction: column; height: 600px; }
-    .chat-container { flex: 1; background: rgba(248,249,250,0.6); border-radius: 15px; padding: 20px; overflow-y: auto; margin-bottom: 20px; border: 1px solid rgba(0,0,0,0.05); }
-    body.dark-mode .chat-container { background: rgba(44,62,80,0.8); border-color: rgba(255,255,255,0.1); }
-    .message { margin: 15px 0; padding: 15px 20px; border-radius: 20px; max-width: 80%; word-wrap: break-word; animation: fadeIn 0.3s ease; }
-    @keyframes fadeIn { from{opacity:0;transform:translateY(10px)} to{opacity:1;transform:translateY(0)} }
-    .message.user { background: #4A90E2; color: #fff; margin-left: auto; border-bottom-right-radius: 5px; }
-    .message.assistant { background: rgba(248,249,250,0.95); color: #2c3e50; margin-right: auto; border-bottom-left-radius: 5px; border: 1px solid rgba(74,144,226,0.1); }
-    body.dark-mode .message.assistant { background: rgba(52,73,94,0.9); color: #ecf0f1; border-color: rgba(255,255,255,0.1); }
-    .typing-indicator { display: none; align-items: center; gap: 10px; padding: 15px 20px; background: rgba(248,249,250,0.95); border-radius: 20px; border-bottom-left-radius: 5px; max-width: 80%; margin: 15px 0; border: 1px solid rgba(74,144,226,0.1); }
-    body.dark-mode .typing-indicator { background: rgba(52,73,94,0.9); border-color: rgba(255,255,255,0.1); }
-    .typing-dots { display: flex; gap: 4px; }
-    .typing-dots span { width: 8px; height: 8px; background: #4A90E2; border-radius: 50%; animation: typing 1.4s infinite ease-in-out; }
-    .typing-dots span:nth-child(1){animation-delay:-0.32s} .typing-dots span:nth-child(2){animation-delay:-0.16s}
-    @keyframes typing { 0%,80%,100%{transform:scale(0.8);opacity:0.5} 40%{transform:scale(1);opacity:1} }
-    .chat-input-container { display: flex; gap: 10px; align-items: center; }
-    .chat-input { flex: 1; padding: 15px 20px; border: 2px solid #FFE082; border-radius: 25px; font-size: 1rem; outline: none; transition: all 0.3s ease; background: rgba(255,255,255,0.95); }
-    body.dark-mode .chat-input { background: rgba(52,73,94,0.9); border-color: #7f8c8d; color: #ecf0f1; }
-    .chat-input:focus { border-color: #4A90E2; box-shadow: 0 0 0 3px rgba(74,144,226,0.1); }
-    .send-button { background: #4A90E2; color: #fff; border: none; border-radius: 50%; width: 50px; height: 50px; cursor: pointer; transition: all 0.3s ease; display: flex; align-items: center; justify-content: center; font-weight: bold; box-shadow: 0 4px 12px rgba(74,144,226,0.3); }
-    .send-button:hover { transform: scale(1.05); box-shadow: 0 6px 16px rgba(74,144,226,0.4); }
-    .privacy-button { background: rgba(255,149,0,0.1); border: 2px solid #FF9500; color: #FF9500; padding: 15px 30px; border-radius: 25px; cursor: pointer; font-weight: bold; margin: 20px auto; display: block; transition: all 0.3s ease; text-align: center; }
-    body.dark-mode .privacy-button { background: rgba(255,149,0,0.2); color: #FFB74D; }
-    .privacy-button:hover { background: rgba(255,149,0,0.2); transform: translateY(-2px); box-shadow: 0 6px 16px rgba(255,149,0,0.3); }
-    .modal { display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.6); z-index: 2000; backdrop-filter: blur(5px); }
-    .modal-content { background: #fff; margin: 5% auto; padding: 30px; border-radius: 20px; width: 90%; max-width: 600px; max-height: 80vh; overflow-y: auto; position: relative; animation: modalSlideIn 0.3s ease; box-shadow: 0 20px 60px rgba(0,0,0,0.2); }
-    body.dark-mode .modal-content { background: #2c3e50; color: #ecf0f1; }
-    @keyframes modalSlideIn { from{ transform: translateY(-50px); opacity:0 } to{ transform: translateY(0); opacity:1 } }
-    .close { position: absolute; top: 15px; right: 20px; font-size: 2rem; cursor: pointer; color: #95a5a6; transition: color 0.3s ease; }
-    .close:hover { color: #e74c3c; }
-    .emergency-section { background: rgba(231,76,60,0.08); border: 2px solid #FFCDD2; border-radius: 15px; padding: 20px; margin: 20px 0; }
-    .emergency-section h3 { color: #D32F2F; margin-bottom: 15px; }
-    .emergency-section p { color: #F44336; font-weight: 600; margin-bottom: 10px; }
-    .privacy-section { background: rgba(76,175,80,0.08); border: 2px solid #C8E6C9; border-radius: 15px; padding: 20px; margin: 20px 0; }
-    .privacy-section h3 { color: #388E3C; margin-bottom: 15px; }
-    .quote { text-align: center; font-style: italic; color: #7B8FA3; margin: 30px 0; font-size: 1.1rem; }
-    body.dark-mode .quote { color: #95a5a6; }
-    .admin-button { display: none; position: fixed; bottom: 20px; right: 20px; background: rgba(52,73,94,0.9); color: #fff; border: none; border-radius: 50%; width: 60px; height: 60px; font-size: 1.5rem; cursor: pointer; backdrop-filter: blur(10px); transition: all 0.3s ease; z-index: 1000; box-shadow: 0 4px 12px rgba(0,0,0,0.2); }
-    .admin-button:hover { transform: scale(1.1); box-shadow: 0 6px 16px rgba(0,0,0,0.3); }
-    .admin-form { display: flex; flex-direction: column; gap: 20px; margin-top: 20px; }
-    .admin-form label { font-weight: 600; color: #2c3e50; }
-    body.dark-mode .admin-form label { color: #ecf0f1; }
-    .admin-form input, .admin-form select { padding: 12px 15px; border: 2px solid #E0E0E0; border-radius: 10px; font-size: 1rem; outline: none; transition: border-color 0.3s ease; }
-    body.dark-mode .admin-form input, body.dark-mode .admin-form select { background: #34495e; border-color: #7f8c8d; color: #ecf0f1; }
-    .admin-form input:focus, .admin-form select:focus { border-color: #4A90E2; }
-    .admin-form button { background: #4A90E2; color: #fff; border: none; padding: 15px 30px; border-radius: 10px; font-size: 1rem; font-weight: bold; cursor: pointer; transition: all 0.3s ease; }
-    .admin-form button:hover { transform: translateY(-2px); box-shadow: 0 6px 16px rgba(74,144,226,0.3); }
-    .toast { position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%) translateY(20px); background: rgba(76,175,80,0.95); color: #fff; padding: 20px 30px; border-radius: 15px; font-weight: bold; z-index: 3000; opacity: 0; transition: all 0.3s ease; backdrop-filter: blur(10px); border: 1px solid rgba(255,255,255,0.2); text-align: center; max-width: 80%; box-shadow: 0 8px 24px rgba(0,0,0,0.2); }
-    .toast.error { background: rgba(244,67,54,0.95); }
+
+    .chat-container {
+      flex: 1;
+      background: rgba(248, 249, 250, 0.7);
+      border-radius: 22px;
+      padding: 24px;
+      overflow-y: auto;
+      margin-bottom: 22px;
+      border: 1px solid rgba(74, 144, 226, 0.12);
+      position: relative;
+    }
+
+    .message {
+      margin: 16px 0;
+      padding: 16px 22px;
+      border-radius: 24px;
+      max-width: 80%;
+      word-wrap: break-word;
+      animation: fadeIn 0.25s ease;
+      box-shadow: 0 12px 24px rgba(15, 33, 54, 0.06);
+      line-height: 1.55;
+      letter-spacing: 0.01em;
+    }
+
+    @keyframes fadeIn { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
+
+    .message.user { background: linear-gradient(135deg, var(--accent-strong), var(--accent)); color: #fff; margin-left: auto; border-bottom-right-radius: 8px; }
+    .message.assistant { background: rgba(255, 255, 255, 0.92); color: var(--text-main); margin-right: auto; border-bottom-left-radius: 8px; border: 1px solid rgba(74, 144, 226, 0.14); }
+
+    body.dark-mode .chat-container { background: rgba(28, 38, 53, 0.75); border-color: rgba(116, 185, 255, 0.12); }
+    body.dark-mode .message.assistant { background: rgba(33, 45, 60, 0.95); border-color: rgba(116, 185, 255, 0.18); }
+
+    .typing-indicator {
+      display: none;
+      align-items: center;
+      gap: 12px;
+      padding: 16px 22px;
+      background: rgba(255, 255, 255, 0.92);
+      border-radius: 22px;
+      border-bottom-left-radius: 8px;
+      max-width: 70%;
+      margin: 16px 0;
+      border: 1px solid rgba(74, 144, 226, 0.18);
+      box-shadow: 0 10px 24px rgba(15, 33, 54, 0.08);
+      color: var(--text-soft);
+    }
+
+    body.dark-mode .typing-indicator { background: rgba(37, 49, 66, 0.95); border-color: rgba(116, 185, 255, 0.18); }
+
+    .typing-dots { display: flex; gap: 5px; }
+    .typing-dots span { width: 9px; height: 9px; background: var(--accent); border-radius: 50%; animation: typing 1.4s infinite ease-in-out; }
+    .typing-dots span:nth-child(1) { animation-delay: -0.32s; }
+    .typing-dots span:nth-child(2) { animation-delay: -0.16s; }
+    @keyframes typing { 0%, 80%, 100% { transform: scale(0.75); opacity: 0.4; } 40% { transform: scale(1); opacity: 1; } }
+
+    .chat-input-container { display: flex; gap: 12px; align-items: center; }
+
+    .chat-input {
+      flex: 1;
+      padding: 16px 20px;
+      border: 2px solid rgba(255, 193, 7, 0.35);
+      border-radius: 999px;
+      font-size: 1rem;
+      outline: none;
+      transition: border-color 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+      background: rgba(255, 255, 255, 0.92);
+      color: var(--text-main);
+    }
+
+    .chat-input:focus { border-color: rgba(74, 144, 226, 0.65); box-shadow: 0 0 0 4px rgba(74, 144, 226, 0.1); }
+    body.dark-mode .chat-input { background: rgba(33, 45, 60, 0.92); border-color: rgba(127, 140, 141, 0.5); color: #f8fbff; }
+
+    .send-button {
+      background: linear-gradient(135deg, var(--accent-strong), var(--accent));
+      color: #fff;
+      border: none;
+      border-radius: 50%;
+      width: 54px;
+      height: 54px;
+      cursor: pointer;
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: bold;
+      box-shadow: 0 16px 32px rgba(74, 144, 226, 0.35);
+    }
+
+    .send-button:hover { transform: translateY(-3px); box-shadow: 0 20px 38px rgba(74, 144, 226, 0.45); }
+
+    .privacy-button {
+      background: rgba(255, 149, 0, 0.12);
+      border: 1px solid rgba(255, 149, 0, 0.35);
+      color: var(--warning);
+      padding: 16px 34px;
+      border-radius: 999px;
+      cursor: pointer;
+      font-weight: 600;
+      margin: 16px auto;
+      display: block;
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
+      text-align: center;
+      grid-column: 1 / -1;
+    }
+
+    .privacy-button:hover { transform: translateY(-3px); box-shadow: 0 12px 28px rgba(255, 149, 0, 0.28); }
+
+    .modal {
+      display: none;
+      position: fixed;
+      top: 0; left: 0;
+      width: 100%; height: 100%;
+      background: rgba(5, 14, 26, 0.65);
+      z-index: 2000;
+      backdrop-filter: blur(8px);
+      padding: 24px;
+    }
+
+    .modal-content {
+      background: var(--card-bg);
+      margin: 3% auto;
+      padding: 32px;
+      border-radius: 24px;
+      width: min(640px, 92vw);
+      max-height: 82vh;
+      overflow-y: auto;
+      position: relative;
+      animation: modalSlideIn 0.35s ease;
+      box-shadow: var(--shadow-soft);
+      border: 1px solid var(--card-border);
+    }
+
+    @keyframes modalSlideIn { from { transform: translateY(-40px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
+
+    .close { position: absolute; top: 18px; right: 22px; font-size: 2rem; cursor: pointer; color: rgba(149, 165, 166, 0.8); transition: color 0.3s ease; }
+    .close:hover { color: var(--danger); }
+
+    .emergency-section { background: rgba(231, 76, 60, 0.08); border: 1px solid rgba(231, 76, 60, 0.25); border-radius: 18px; padding: 22px; margin: 22px 0; }
+    .emergency-section h3 { color: var(--danger); margin-bottom: 16px; }
+    .emergency-section p { color: rgba(211, 47, 47, 0.85); font-weight: 600; margin-bottom: 10px; }
+
+    .privacy-section { background: rgba(46, 204, 113, 0.08); border: 1px solid rgba(46, 204, 113, 0.25); border-radius: 18px; padding: 22px; margin: 22px 0; color: var(--text-soft); }
+    .privacy-section h3 { color: var(--success); margin-bottom: 16px; }
+
+    .quote { text-align: center; font-style: italic; color: var(--text-soft); margin: 32px 0 12px; font-size: 1.1rem; }
+
+    .admin-button {
+      display: none;
+      position: fixed;
+      bottom: 24px;
+      right: 24px;
+      background: linear-gradient(135deg, rgba(38, 52, 68, 0.92), rgba(54, 71, 92, 0.92));
+      color: #fff;
+      border: none;
+      border-radius: 50%;
+      width: 62px;
+      height: 62px;
+      font-size: 1.5rem;
+      cursor: pointer;
+      backdrop-filter: blur(14px);
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
+      z-index: 1000;
+      box-shadow: 0 12px 28px rgba(15, 23, 42, 0.35);
+    }
+
+    .admin-button:hover { transform: translateY(-3px) scale(1.04); box-shadow: 0 18px 38px rgba(15, 23, 42, 0.45); }
+
+    .admin-form { display: flex; flex-direction: column; gap: 22px; margin-top: 28px; }
+    .admin-form label { font-weight: 600; color: var(--text-main); letter-spacing: 0.01em; }
+    .admin-form input, .admin-form select { padding: 13px 16px; border: 1px solid rgba(149, 165, 166, 0.35); border-radius: 12px; font-size: 1rem; outline: none; transition: border-color 0.3s ease, box-shadow 0.3s ease; background: rgba(255, 255, 255, 0.9); color: var(--text-main); }
+    .admin-form input:focus, .admin-form select:focus { border-color: rgba(74, 144, 226, 0.55); box-shadow: 0 0 0 4px rgba(74, 144, 226, 0.12); }
+    .admin-form button { background: linear-gradient(135deg, var(--accent-strong), var(--accent)); color: #fff; border: none; padding: 15px 30px; border-radius: 12px; font-size: 1rem; font-weight: bold; cursor: pointer; transition: transform 0.3s ease, box-shadow 0.3s ease; }
+    .admin-form button:hover { transform: translateY(-3px); box-shadow: 0 16px 32px rgba(74, 144, 226, 0.35); }
+
+    .toast { position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%) translateY(20px); background: rgba(46, 204, 113, 0.95); color: #fff; padding: 20px 30px; border-radius: 15px; font-weight: bold; z-index: 3000; opacity: 0; transition: all 0.3s ease; backdrop-filter: blur(10px); border: 1px solid rgba(255, 255, 255, 0.2); text-align: center; max-width: 80%; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2); }
+    .toast.error { background: rgba(244, 67, 54, 0.95); }
     .toast.show { opacity: 1; transform: translate(-50%, -50%) translateY(0); }
-    .emergency-footer { grid-column: 1 / -1; background: rgba(231,76,60,0.08); border: 2px solid #FFCDD2; border-radius: 20px; padding: 30px; margin-top: 30px; }
-    .emergency-footer h2 { color: #D32F2F; text-align: center; margin-bottom: 25px; font-size: 1.8rem; }
-    .country-section { margin: 20px 0; padding: 15px; background: rgba(255,255,255,0.7); border-radius: 15px; border-left: 5px solid #F44336; }
-    body.dark-mode .country-section { background: rgba(52,73,94,0.5); }
-    .country-section h3 { color: #D32F2F; margin-bottom: 15px; display: flex; align-items: center; gap: 10px; }
-    .contact-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 10px; }
-    .contact-item { background: rgba(231,76,60,0.05); padding: 10px 15px; border-radius: 10px; border: 1px solid rgba(231,76,60,0.2); transition: all 0.3s ease; }
-    .contact-item:hover { background: rgba(231,76,60,0.1); transform: translateY(-2px); }
-    .contact-item strong { color: #D32F2F; }
+
+    .card ol { color: var(--text-soft); line-height: 1.6; margin-left: 18px; }
+    body.dark-mode .card ol { color: #d5dde5; }
+
+    .emergency-footer {
+      grid-column: 1 / -1;
+      background: rgba(231, 76, 60, 0.08);
+      border: 1px solid rgba(231, 76, 60, 0.22);
+      border-radius: 24px;
+      padding: 34px;
+      margin-top: 30px;
+    }
+
+    .emergency-footer h2 { color: var(--danger); text-align: center; margin-bottom: 25px; font-size: 1.8rem; letter-spacing: 0.01em; }
+
+    .country-section { margin: 20px 0; padding: 18px; background: rgba(255, 255, 255, 0.7); border-radius: 18px; border-left: 5px solid rgba(244, 67, 54, 0.65); }
+    body.dark-mode .country-section { background: rgba(33, 45, 60, 0.72); }
+    .country-section h3 { color: var(--danger); margin-bottom: 15px; display: flex; align-items: center; gap: 10px; }
+
+    .contact-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 12px; }
+    .contact-item { background: rgba(231, 76, 60, 0.05); padding: 12px 16px; border-radius: 12px; border: 1px solid rgba(231, 76, 60, 0.2); transition: transform 0.3s ease, box-shadow 0.3s ease; }
+    .contact-item:hover { background: rgba(231, 76, 60, 0.1); transform: translateY(-2px); box-shadow: 0 10px 18px rgba(244, 67, 54, 0.18); }
+    .contact-item strong { color: var(--danger); }
+
     .chat-container::-webkit-scrollbar { width: 8px; }
-    .chat-container::-webkit-scrollbar-track { background: rgba(0,0,0,0.05); border-radius: 10px; }
-    .chat-container::-webkit-scrollbar-thumb { background: rgba(74,144,226,0.6); border-radius: 10px; }
-    .chat-container::-webkit-scrollbar-thumb:hover { background: rgba(74,144,226,0.8); }
+    .chat-container::-webkit-scrollbar-track { background: rgba(0, 0, 0, 0.05); border-radius: 10px; }
+    .chat-container::-webkit-scrollbar-thumb { background: rgba(74, 144, 226, 0.6); border-radius: 10px; }
+    .chat-container::-webkit-scrollbar-thumb:hover { background: rgba(74, 144, 226, 0.8); }
+
     @media (max-width: 480px) {
-      body{ padding:10px } .card{ padding:20px } .header h1{ font-size:2rem }
-      .microphone-button{ width:100px; height:100px; font-size:2rem }
-      .chat-section{ height:500px } .message{ max-width:90% }
-      .contact-grid{ grid-template-columns:1fr }
+      .card { padding: 24px; }
+      .header h1 { font-size: 2.4rem; }
+      .microphone-button { width: 108px; height: 108px; font-size: 2.2rem; }
+      .chat-section { height: 520px; }
+      .message { max-width: 92%; }
+      .contact-grid { grid-template-columns: 1fr; }
     }
   </style>
 </head>
 <body>
   <button class="theme-toggle" id="themeToggle">🌙</button>
-  <div class="status-bar" id="statusBar">⚠️ Modalità Demo</div>
+  <div class="status-bar demo" id="statusBar">⏳ Avvio…</div>
   <button class="admin-button" id="adminBtn">⚙️</button>
 
   <div class="container">
@@ -150,7 +525,7 @@
       <h2 class="section-title">🎤 Comunicazione Vocale</h2>
       <div class="microphone-section">
         <button class="microphone-button" id="microphoneButton">🎤</button>
-        <div class="microphone-status" id="microphoneStatus">Microfono sempre attivo</div>
+        <div class="microphone-status" id="microphoneStatus">Microfono pronto ad ascoltarti</div>
         <div class="transcript-area" id="transcriptArea">La trascrizione in tempo reale apparirà qui...</div>
         <div class="microphone-help">
           <h4>🔓 Come sbloccare il microfono:</h4>
@@ -163,7 +538,7 @@
       </div>
     </div>
 
-    <div class="card">
+    <div class="card card--full">
       <h2 class="section-title">💬 Chat con Alu</h2>
       <div class="chat-section">
         <div class="chat-container" id="chatContainer">
@@ -310,6 +685,8 @@
         this.isSpeaking = false;
         this.ignoreAsrUntil = 0;
         this.postTtsCooldownMs = 900;
+        this.hasPendingRequest = false;
+        this.demoNoticeShown = false;
 
         this.desktopFix = {
           maxRetries: 5, currentRetries: 0, isDesktop: !this.isMobileDevice(),
@@ -331,9 +708,15 @@
       }
 
       setStatus(kind, text) {
-        this.statusBar.classList.remove('connected', 'error');
+        if (!this.statusBar) return;
+        this.statusBar.classList.remove('connected', 'error', 'demo');
         if (kind) this.statusBar.classList.add(kind);
-        if (text) this.statusBar.textContent = text;
+        const defaultText = kind === 'connected'
+          ? '✅ Connesso a OpenAI'
+          : kind === 'error'
+            ? '❌ Errore di connessione'
+            : '⚠️ Modalità Demo';
+        this.statusBar.textContent = text || defaultText;
       }
 
       isMobileDevice() {
@@ -354,6 +737,7 @@
         this.adminBtn = document.getElementById('adminBtn');
         this.privacyModal = document.getElementById('privacyModal');
         this.adminModal = document.getElementById('adminModal');
+        this.statusBar?.setAttribute('aria-live', 'polite');
       }
 
       initSpeechRecognition() {
@@ -557,7 +941,7 @@
           this.microphoneStatus.classList.remove('disabled');
         } else {
           this.microphoneButton.classList.remove('listening', 'disabled');
-          this.microphoneStatus.textContent = 'Microfono sempre attivo';
+          this.microphoneStatus.textContent = 'Microfono pronto ad ascoltarti';
           this.microphoneStatus.classList.remove('active', 'disabled');
         }
       }
@@ -577,10 +961,13 @@
       }
 
       processVoiceInput(text) {
+        if (this.hasPendingRequest) {
+          this.showToast('Attendi la risposta di Alu prima di parlare di nuovo', 'error');
+          return;
+        }
         this.isProcessing = true;
         this.addMessage(text, 'user');
-        this.sendToAssistant(text);
-        setTimeout(() => { this.isProcessing = false; }, 3000);
+        this.sendToAssistant(text).finally(() => { this.isProcessing = false; });
       }
 
       addMessage(content, type) {
@@ -594,13 +981,19 @@
       sendMessage() {
         const message = this.chatInput.value.trim();
         if (message) {
+          if (this.hasPendingRequest) {
+            this.showToast('Attendi la risposta di Alu prima di inviare un nuovo messaggio', 'error');
+            return;
+          }
           this.addMessage(message, 'user');
-          this.sendToAssistant(message);
           this.chatInput.value = '';
+          this.sendToAssistant(message);
         }
       }
 
       async sendToAssistant(message) {
+        this.hasPendingRequest = true;
+        this.isProcessing = true;
         this.showTyping();
         try {
           this.conversationHistory.push({ role: 'user', content: message });
@@ -631,15 +1024,36 @@
             };
           }
 
-          const response = edvResult.content || this.getDemoResponse(message);
+          const normalized = this.normalizeAssistantResponse(edvResult, message);
+          const response = normalized.text;
 
-          this.setStatus('connected', '✅ Connesso a OpenAI');
+          if (normalized.hasError) {
+            this.setStatus('error', normalized.statusText || '❌ Errore di connessione');
+            if (normalized.statusText) {
+              this.showToast(normalized.statusText, 'error');
+            }
+          } else if (normalized.isDemo) {
+            this.setStatus('demo', normalized.statusText || '⚠️ Modalità Demo');
+            if (normalized.statusText && !this.demoNoticeShown) {
+              this.showToast(normalized.statusText, 'error');
+              this.demoNoticeShown = true;
+            }
+          } else {
+            this.setStatus('connected', '✅ Connesso a OpenAI');
+            this.demoNoticeShown = false;
+          }
+
           this.conversationHistory.push({ role: 'assistant', content: response });
-          this.hideTyping();
           this.addMessage(response, 'assistant');
+          this.hideTyping();
 
           this.ignoreAsrUntil = Date.now() + 2000;
-          await this.speakWithOpenAI(response);
+
+          if (normalized.hasError || normalized.isDemo) {
+            this.speakWithNativeTTS(response);
+          } else {
+            await this.speakWithOpenAI(response);
+          }
 
           if (this.conversationHistory.length > 40) {
             this.conversationHistory = this.conversationHistory.slice(-20);
@@ -648,12 +1062,28 @@
           console.warn('sendToAssistant error:', err);
           this.hideTyping();
           const fallback = this.getDemoResponse(message);
+          this.conversationHistory.push({ role: 'assistant', content: fallback });
           this.addMessage(fallback, 'assistant');
           this.ignoreAsrUntil = Date.now() + 2000;
           this.speakWithNativeTTS(fallback);
-          this.setStatus('error', '❌ Errore connessione');
+          this.setStatus('error', '❌ Errore di connessione');
           this.showToast('Errore di rete o endpoint non raggiungibile', 'error');
+          this.demoNoticeShown = false;
+        } finally {
+          this.hideTyping();
+          this.isProcessing = false;
+          this.hasPendingRequest = false;
         }
+      }
+
+      normalizeAssistantResponse(edvResult, fallbackSource) {
+        const raw = edvResult?.raw || {};
+        const content = typeof edvResult?.content === 'string' ? edvResult.content.trim() : '';
+        const text = content || this.getDemoResponse(fallbackSource);
+        const statusText = raw?.error || raw?.warning || raw?.message || raw?.status || raw?.statusText || null;
+        const isDemo = Boolean(raw?.warning || raw?.demo || raw?.mode === 'demo' || raw?.status === 'demo');
+        const hasError = Boolean(raw?.error);
+        return { text, raw, statusText, isDemo, hasError };
       }
 
       async speakWithOpenAI(text) {


### PR DESCRIPTION
## Summary
- restyle the landing UI with a glassmorphism-inspired layout, responsive grid, and refined component theming
- improve assistant flow control by blocking overlapping requests, surfacing demo/warning states, and falling back gracefully to native TTS
- polish status and microphone messaging defaults to match the refreshed experience

## Testing
- not run (UI changes only)

------
https://chatgpt.com/codex/tasks/task_e_68e1683aff0c8326a1fcff1f86f671e9