### PR TITLE
Remove quick start guide and default therapist prompt

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -16,7 +16,9 @@ module.exports = async (req, res) => {
 
   const messages = Array.isArray(body.messages) ? body.messages : [];
   const assistantId = typeof body.assistantId === 'string' ? body.assistantId.trim() : '';
-  const promptId = typeof body.promptId === 'string' ? body.promptId.trim() : '';
+  const bodyPromptId = typeof body.promptId === 'string' ? body.promptId.trim() : '';
+  const DEFAULT_PROMPT_ID = 'pmpt_68b5876fea1081908e6b472c85d6489a042e34dea2f3df83';
+  const effectivePromptId = assistantId ? '' : (bodyPromptId || DEFAULT_PROMPT_ID);
 
   const sys = `Sei Alu, un assistente di supporto psicologico empatico e professionale.
 Caratteristiche:
@@ -42,7 +44,10 @@ Caratteristiche:
     content: [{ type: 'text', text: m.content }]
   }));
 
-  const useResponsesApi = Boolean((assistantId && assistantId.startsWith('asst_')) || (promptId && promptId.startsWith('pmpt_')));
+  const useResponsesApi = Boolean(
+    (assistantId && assistantId.startsWith('asst_'))
+    || (effectivePromptId && effectivePromptId.startsWith('pmpt_'))
+  );
 
   const chatPayload = {
     model: 'gpt-4o-mini',
@@ -58,7 +63,7 @@ Caratteristiche:
   };
 
   if (assistantId) responsesPayload.assistant_id = assistantId;
-  if (!assistantId && promptId) responsesPayload.prompt_id = promptId;
+  if (!assistantId && effectivePromptId) responsesPayload.prompt_id = effectivePromptId;
   if (!responsesPayload.input) delete responsesPayload.input;
 
   try {

--- a/index.html
+++ b/index.html
@@ -510,18 +510,6 @@
     </div>
 
     <div class="card">
-      <h2 class="section-title">🧭 Guida rapida</h2>
-      <ol style="color:#52637a; line-height:1.6; margin-left:18px;">
-        <li><strong>Se stai guardando il repository su GitHub vedrai solo il codice</strong>: per usare l'app devi aprirla da gTab o da un server web (HTTPS o <code>localhost</code>).</li>
-        <li><strong>Apri la pagina da gTab in HTTPS</strong> oppure su <code>localhost</code> per poter abilitare il microfono.</li>
-        <li>Clicca l'icona 🔒 del browser e <strong>consenti l'accesso al microfono</strong>, poi ricarica la scheda se richiesto.</li>
-        <li><strong>Doppio clic sullo sfondo</strong> della pagina e inserisci il codice <code>ALUIA2025</code> per sbloccare il pannello ⚙️.</li>
-        <li>Nel pannello amministratore inserisci l'<em>Assistant ID</em> se disponibile e verifica che il <em>Prompt ID</em> sia <code>pmpt_68b5876fea1081908e6b472c85d6489a042e34dea2f3df83</code>.</li>
-        <li>Scegli la voce desiderata, salva la configurazione e prova il microfono con il pulsante grande blu.</li>
-      </ol>
-    </div>
-
-    <div class="card">
       <h2 class="section-title">🎤 Comunicazione Vocale</h2>
       <div class="microphone-section">
         <button class="microphone-button" id="microphoneButton">🎤</button>


### PR DESCRIPTION
## Summary
- remove the quick start guide card from the home layout to streamline the UI
- default the chat backend to use therapist prompt pmpt_68b5876fea1081908e6b472c85d6489a042e34dea2f3df83 when no assistant is configured

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3c0f9f9f883268ebc2f03d8b1b010